### PR TITLE
fix: pass -Project in CommonPlugin so UBT resolves the plugin module …

### DIFF
--- a/src/Nuke.Unreal/Plugins/UnrealPlugin.cs
+++ b/src/Nuke.Unreal/Plugins/UnrealPlugin.cs
@@ -632,6 +632,7 @@ public class UnrealPlugin
                     .Apply(Common)
                 ;
                 UbtConfig CommonPlugin(UbtConfig _) => _
+                    .Project(shortHostProjectDir / "HostProject.uproject")
                     .Plugin(shortPluginDir / PluginPath.Name)
                     .Apply(Common)
                 ;


### PR DESCRIPTION
Sadly UE 5.8 no longer locates a plugin's module from -Plugin alone for some reason `RulesError`. CommonProject already passes -Project; I mirrored it in CommonPlugin.